### PR TITLE
fix systemd drop-in unit (ExecStart)

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
 # handlers file for gitlab_runner
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+
 - name: restart gitlab-runner
   service:
     name: "{{ gitlab_runner_service }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
     src: exec_start.conf.j2
     dest: /etc/systemd/system/gitlab-runner.service.d/exec_start.conf
   notify:
+    - reload systemd
     - restart gitlab-runner
 
 - name: start and enable gitlab-runner

--- a/templates/exec_start.conf.j2
+++ b/templates/exec_start.conf.j2
@@ -1,2 +1,3 @@
 [Service]
+ExecStart=
 ExecStart=/usr/lib/gitlab-runner/gitlab-runner "run" "--working-directory" "{{ gitlab_runner_home_directory }}" "--config" "{{ gitlab_runner_config }}" "--service" "{{ gitlab_runner_service }}" "--syslog" "--user" "{{ gitlab_runner_user }}"


### PR DESCRIPTION
Refer to issue #1

**Describe the change**

To override ExecStart setting in the gitlab-runner systemd unit, we explicitly clear ExecStart before setting it again.

As it's described on ArchLinux documentation (second example): https://wiki.archlinux.org/index.php/systemd#Examples 
(and as said Lennart Poettering: https://bugzilla.redhat.com/show_bug.cgi?id=756787#c9)

We also reload systemd manager if drop-in file for the gitlab-runner service changes.

**Testing**
Role tested with molecule (centos 7) and played on our server (CentOS 7.6) with success.

---

Thanks again for your work
