### PR TITLE
Do not escalate privileges when delegated to localhost

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   ansible.builtin.import_tasks: assert.yml
   run_once: yes
   delegate_to: localhost
+  become: false
 
 - name: install requirements
   ansible.builtin.package:


### PR DESCRIPTION

---
name: Pull request
about: Do not escalate privileges when delegated to localhost

---

**Describe the change**
* Not necessary to use 'become', but set to 'true' on playbook level (see
  example playbook in 'molecule/default/prepare.yml').
* Not working when 'ansible_password' and 'ansible_become_password' are
  set for each node
  * Ansible will try to escalate privileges on localhost with the access
    credentials of the target host
