### PR TITLE
Allow unprivileged runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ gitlab_runner_version: "15.5.0"
 
 # Set the amount of concurrent jobs.
 gitlab_runner_concurrency: "{{ ansible_processor_vcpus }}"
+
+# Activate or deactivate privileged runner
+gitlab_runner_privileged: true
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,6 @@ gitlab_runner_version: "15.5.0"
 
 # Set the amount of concurrent jobs.
 gitlab_runner_concurrency: "{{ ansible_processor_vcpus }}"
+
+# Activate or deactivate privileged runner
+gitlab_runner_privileged: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,8 +45,10 @@
           --tag-list "{{ gitlab_runner_tags | join(',') }}"
           --executor "{{ gitlab_runner_executor }}"
           --docker-image "{{ gitlab_runner_docker_image }}"
+          {% if gitlab_runner_privileged %}
           --docker-privileged
           --docker-volumes /var/run/docker.sock:/var/run/docker.sock
+          {% endif %}
           --locked="false"
           --request-concurrency "{{ gitlab_runner_concurrency }}"
       when:


### PR DESCRIPTION
---

about: Allows the user to set up a runner without privileged mode.

---

**Describe the change**
To allow the user of the role to set up a gitlab runner without privileged mode, a new variable has been introduced.
When registering, it is now checked whether this variable is true. If not, the flags for a privileged runner are omitted.

**Testing**
 Role tested in local test environment with success.