### PR TITLE
Introduce gitlab_runner_package_state which can be set to latest

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,6 @@ gitlab_runner_concurrency: "{{ ansible_processor_vcpus }}"
 
 # Activate or deactivate privileged runner
 gitlab_runner_privileged: true
+
+# The type of package state. Choose from: "present" or "latest"
+gitlab_runner_package_state: present

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -65,3 +65,10 @@
       - gitlab_runner_concurrency is number
       - gitlab_runner_concurrency >= 0
     quiet: yes
+
+- name: assert | Test if gitlab_runner_package_state is set correctly
+  ansible.builtin.assert:
+    that:
+      - gitlab_runner_package_state is string
+      - gitlab_runner_package_state in [ "present", "latest" ]
+    quiet: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Install gitlab-runner
   ansible.builtin.package:
     name: "{{ gitlab_runner_package }}"
-    state: present
+    state: "{{ gitlab_runner_package_state }}"
 
 - name: Register runner
   when:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -51,4 +51,6 @@ _gitlab_runner_version_separator:
 
 gitlab_runner_version_separator: "{{ _gitlab_runner_version_separator[ansible_pkg_mgr] }}"
 
-gitlab_runner_package: "gitlab-runner{{ gitlab_runner_version_separator }}{{ gitlab_runner_version }}"
+gitlab_runner_package_name: gitlab-runner
+
+gitlab_runner_package: "{{ gitlab_runner_package_name }}{% if gitlab_runner_package_state == 'present' %}{{ gitlab_runner_version_separator }}{{ gitlab_runner_version }}{% endif %}"


### PR DESCRIPTION
---
name: Introduce gitlab_runner_package_state which can be set to latest
about: Allows to optionally install always the latest version of the gitlab-runner package

---

**Describe the change**
While some environments target a specific version of the gitlab-runner package (as stated in the configuration), others might want always the latest version. This change introduces an additional option that allows to satisfy these needs.

**Testing**
Role has been tested in a local test environment with and without the new option.