### PR TITLE
Limit concurrent jobs on registered runners

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,14 @@
     name: "{{ gitlab_runner_package }}"
     state: present
 
+- name: Limit concurrent jobs on registered runners
+  ansible.builtin.lineinfile:
+    path: /etc/gitlab-runner/config.toml
+    regexp: '^concurrent = .*'
+    line: 'concurrent = {{ gitlab_runner_concurrent | int }}'
+    insertbefore: BOF
+  when: gitlab_runner_concurrent is defined
+
 - name: Register runner
   when:
     - gitlab_runner_registration_token is defined


### PR DESCRIPTION
---
name: Limit concurrent jobs on registered runners
about: Limit concurrent jobs on registered runners in `/etc/gitlab-runner/config.toml` configuration file

---

**Describe the change**
Implement `concurrent` in global section as described at [GitLab Advanced configuration](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section), might be needed depending on the specific setup.

**Testing**
Role has been tested in a local test environment.